### PR TITLE
Update ssh2 lib to v1.4.0

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -10,5 +10,5 @@ shards:
 
   ssh2:
     github: spider-gazelle/ssh2.cr
-    version: 1.2.4
+    version: 1.4.0
 

--- a/shard.yml
+++ b/shard.yml
@@ -14,7 +14,7 @@ dependencies:
     branch: master
   ssh2:
     github: spider-gazelle/ssh2.cr
-    version: 1.2.4
+    version: 1.4.0
 
 development_dependencies:
   spectator:


### PR DESCRIPTION
This is needed for newer Crystal compatibility.