### PR TITLE
Do not wait for non-watched async commands to exit

### DIFF
--- a/src/docker/ssh_docker_executor.cr
+++ b/src/docker/ssh_docker_executor.cr
@@ -48,8 +48,10 @@ module Swm
       begin
         yield
       ensure
-        signal_channel.close
-        exit_channel.receive
+        if watch
+          signal_channel.close
+          exit_channel.receive
+        end
       end
     end
 


### PR DESCRIPTION
This bug made every `watch`ed command hang indefinitely.